### PR TITLE
Add tibero-fdw github action for other OS systems

### DIFF
--- a/.github/workflows/deploy-tibero-fdw-centos7.yaml
+++ b/.github/workflows/deploy-tibero-fdw-centos7.yaml
@@ -1,0 +1,87 @@
+name: deploy-tibero-fdw-centos7
+
+on:
+  workflow_call:
+    secrets:
+      git-access-token:
+        description: 'Access token for Github'
+        required: true
+
+env:
+  DEPLOY_REPO: tmaxopensql/tibero-fdw-dist
+  BUILD_OS: centos7
+
+jobs:
+  deploy-tibero-fdw-centos:
+    runs-on: ubuntu-20.04
+    container:
+      image: centos:7
+    
+    steps:      
+    - name: home
+      run: |
+        cd /home  
+      
+    - name: Install PostgreSQL
+      run: |
+        yum update -y
+        yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+        yum install -y http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-1.noarch.rpm 
+        yum install -y centos-release-scl-rh epel-release devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-static make gcc git
+        yum install -y postgresql14 postgresql14-server postgresql14-devel      
+          
+    - name: Checkout repository
+      uses: actions/checkout@v2
+        
+    - name: Build tibero-fdw 
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/lib
+        export PATH=/usr/pgsql-14/bin:$PATH
+        make USE_PGXS=1
+        
+    - name: Checkout deploy repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ env.DEPLOY_REPO }}
+        ref: main
+        token: ${{ secrets.git-access-token }}
+        path: tibero-fdw-dist
+      
+    - name: Deploy to tibero-fdw-dist
+      run: |
+        cp tibero_fdw.so tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp tibero_fdw.control tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp *.sql tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp Makefile tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp setenv.sh tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r sql/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r expected/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cd lib/
+        cp * ../tibero-fdw-dist/${{ env.BUILD_OS }}/lib/
+        cd ..
+        ls
+        
+        
+        
+    - name: Initialize Git repository
+      run: |
+        cd tibero-fdw-dist/
+        pwd
+        git init
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+        git config --list
+        git remote -v
+        
+    
+    - name: git push
+      run: |
+        ls
+        cd tibero-fdw-dist/${{ env.BUILD_OS }}/
+        git add .
+        if [[ -n $(git diff --cached --exit-code) ]]; then
+          git commit -m "Deploy libraries"
+          git push -u origin main
+        else
+          echo "No changes to commit"
+        fi

--- a/.github/workflows/deploy-tibero-fdw-centos8.yaml
+++ b/.github/workflows/deploy-tibero-fdw-centos8.yaml
@@ -1,0 +1,90 @@
+name: deploy-tibero-fdw-centos8
+
+on:
+  workflow_call:
+    secrets:
+      git-access-token:
+        description: 'Access token for Github'
+        required: true
+
+env:
+  DEPLOY_REPO: tmaxopensql/tibero-fdw-dist
+  BUILD_OS: centos8
+
+jobs:
+  deploy-tibero-fdw-centos8:
+    runs-on: ubuntu-20.04
+    container:
+      image: centos:8
+    
+    steps:      
+    - name: home
+      run: |
+        cd /home
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+      
+    - name: Install PostgreSQL
+      run: |
+        dnf update -y
+        dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+        dnf install -y http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-1.noarch.rpm 
+        dnf -y group install "Development Tools"
+        dnf -qy module disable postgresql
+        dnf install -y postgresql14-server postgresql14-devel      
+          
+    - name: Checkout repository
+      uses: actions/checkout@v2
+        
+    - name: Build tibero-fdw 
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/lib
+        export PATH=/usr/pgsql-14/bin:$PATH
+        make USE_PGXS=1
+        
+    - name: Checkout deploy repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ env.DEPLOY_REPO }}
+        ref: main
+        token: ${{ secrets.git-access-token }}
+        path: tibero-fdw-dist
+      
+    - name: Deploy to tibero-fdw-dist
+      run: |
+        cp tibero_fdw.so tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp tibero_fdw.control tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp *.sql tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp Makefile tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp setenv.sh tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r sql/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r expected/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cd lib/
+        cp * ../tibero-fdw-dist/${{ env.BUILD_OS }}/lib/
+        cd ..
+        ls
+        
+        
+        
+    - name: Initialize Git repository
+      run: |
+        cd tibero-fdw-dist/
+        pwd
+        git init
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+        git config --list
+        git remote -v
+        
+    
+    - name: git push
+      run: |
+        ls
+        cd tibero-fdw-dist/${{ env.BUILD_OS }}/
+        git add .
+        if [[ -n $(git diff --cached --exit-code) ]]; then
+          git commit -m "Deploy libraries"
+          git push -u origin main
+        else
+          echo "No changes to commit"
+        fi

--- a/.github/workflows/deploy-tibero-fdw-redhat7.yaml
+++ b/.github/workflows/deploy-tibero-fdw-redhat7.yaml
@@ -1,0 +1,88 @@
+name: deploy-tibero-fdw-redhat7
+
+on:
+  workflow_call:
+    secrets:
+      git-access-token:
+        description: 'Access token for Github'
+        required: true
+
+env:
+  DEPLOY_REPO: tmaxopensql/tibero-fdw-dist
+  BUILD_OS: redhat7
+
+jobs:
+  deploy-tibero-fdw-centos:
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.access.redhat.com/rhel7
+    
+    steps:      
+    - name: home
+      run: |
+        cd /home  
+      
+    - name: Install PostgreSQL
+      run: |
+        yum update -y
+        yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+        yum install -y http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-1.noarch.rpm 
+        yum install -y centos-release-scl-rh epel-release devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-static make gcc git
+        yum install -y postgresql14 postgresql14-server postgresql14-devel      
+          
+    - name: Checkout repository
+      uses: actions/checkout@v2
+        
+    - name: Build tibero-fdw 
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/lib
+        export PATH=/usr/pgsql-14/bin:$PATH
+        make USE_PGXS=1
+        
+    - name: Checkout deploy repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ env.DEPLOY_REPO }}
+        ref: main
+        token: ${{ secrets.git-access-token }}
+        path: tibero-fdw-dist
+      
+    - name: Deploy to tibero-fdw-dist
+      run: |
+        cp tibero_fdw.so tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp tibero_fdw.control tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp *.sql tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp Makefile tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp setenv.sh tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r sql/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r expected/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cd lib/
+        cp * ../tibero-fdw-dist/${{ env.BUILD_OS }}/lib/
+        cd ..
+        ls
+        
+        
+        
+    - name: Initialize Git repository
+      run: |
+        cd tibero-fdw-dist/
+        pwd
+        git init
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+        git config --list
+        git remote -v
+        
+    
+    - name: git push
+      run: |
+        ls
+        cd tibero-fdw-dist/${{ env.BUILD_OS }}/
+        git add .
+        if [[ -n $(git diff --cached --exit-code) ]]; then
+          git commit -m "Deploy libraries"
+          git push -u origin main
+        else
+          echo "No changes to commit"
+        fi
+

--- a/.github/workflows/deploy-tibero-fdw-redhat8.yaml
+++ b/.github/workflows/deploy-tibero-fdw-redhat8.yaml
@@ -1,0 +1,92 @@
+name: deploy-tibero-fdw-redhat8
+
+on:
+  workflow_call:
+    secrets:
+      git-access-token:
+        description: 'Access token for Github'
+        required: true
+
+env:
+  DEPLOY_REPO: tmaxopensql/tibero-fdw-dist
+  BUILD_OS: redhat8
+
+jobs:
+  deploy-tibero-fdw-redhat8:
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.access.redhat.com/ubi8/ubi:latest
+    
+    steps:      
+    - name: home
+      run: |
+        cd /home  
+        
+    - name: Stop rhsmcertd.service
+      run: |
+        service rhsmcertd stop
+        chkconfig rhsmcertd off
+      
+    - name: Install PostgreSQL
+      run: |
+        yum update -y
+        yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+        yum install -y http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-1.noarch.rpm 
+        yum install -y centos-release-scl-rh epel-release devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-static make gcc git
+        yum install -y postgresql14 postgresql14-server postgresql14-devel      
+          
+    - name: Checkout repository
+      uses: actions/checkout@v2
+        
+    - name: Build tibero-fdw 
+      run: |
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/lib
+        export PATH=/usr/pgsql-14/bin:$PATH
+        make USE_PGXS=1
+        
+    - name: Checkout deploy repository
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ env.DEPLOY_REPO }}
+        ref: main
+        token: ${{ secrets.git-access-token }}
+        path: tibero-fdw-dist
+      
+    - name: Deploy to tibero-fdw-dist
+      run: |
+        cp tibero_fdw.so tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp tibero_fdw.control tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp *.sql tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp Makefile tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp setenv.sh tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r sql/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r expected/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cd lib/
+        cp * ../tibero-fdw-dist/${{ env.BUILD_OS }}/lib/
+        cd ..
+        ls
+        
+        
+        
+    - name: Initialize Git repository
+      run: |
+        cd tibero-fdw-dist/
+        pwd
+        git init
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git config --global user.name "${{ github.actor }}"
+        git config --list
+        git remote -v
+        
+    
+    - name: git push
+      run: |
+        ls
+        cd tibero-fdw-dist/${{ env.BUILD_OS }}/
+        git add .
+        if [[ -n $(git diff --cached --exit-code) ]]; then
+          git commit -m "Deploy libraries"
+          git push -u origin main
+        else
+          echo "No changes to commit"
+        fi

--- a/.github/workflows/deploy-tibero-fdw-ubuntu20.04.yaml
+++ b/.github/workflows/deploy-tibero-fdw-ubuntu20.04.yaml
@@ -1,22 +1,25 @@
-name: deploy-tibero-fdw-Ubuntu20.04 
+name: deploy-tibero-fdw-ubuntu20.04 
 
 on:
-  workflow_dispatch: #for dispatch
-  push:
-    branches:
-      - main     
+  workflow_call:
+    secrets:
+      git-access-token:
+        description: 'Access token for Github'
+        required: true
+
 
 env: 
-  DEPLOY_REPO: hypersql/tibero-fdw-dist
+  DEPLOY_REPO: tmaxopensql/tibero-fdw-dist
+  BUILD_OS: ubuntu20.04
 
 jobs:
-  deploy-Tiberofdw-Ubuntu:
+  deploy-tibero-fdw-ubuntu:
     runs-on: ubuntu-20.04
     
-    steps:
-    - name: Checkout tibero-fdw source code
+    steps:      
+    - name: Checkout repository
       uses: actions/checkout@v2
-      
+    
     - name: Add PGDG repository
       run: |
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -30,10 +33,7 @@ jobs:
     - name: Build tibero-fdw 
       run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/lib
-        echo $LD_LIBRARY_PATH
-        ls $GITHUB_WORKSPACE/lib
         make USE_PGXS=1
-        ldd tibero_fdw.so
       
         
     - name: Checkout deploy replository
@@ -41,7 +41,7 @@ jobs:
       with:
         repository: ${{ env.DEPLOY_REPO }}
         ref: main
-        token: ${{ secrets.HYPERSQL_GITHUB_ACCESS_TOKEN }}
+        token: ${{ secrets.git-access-token }}
         path: tibero-fdw-dist
     
     - name: Deploy to tibero-fdw-dist
@@ -49,18 +49,17 @@ jobs:
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
         git config --global user.name "${{ github.actor }}"
         
-        cp tibero_fdw.so tibero-fdw-dist/ubuntu20.04/
-        cp tibero_fdw.control tibero-fdw-dist/ubuntu20.04/
-        cp *.sql tibero-fdw-dist/ubuntu20.04/
-        cp Makefile tibero-fdw-dist/ubuntu20.04/
-        cp setenv.sh tibero-fdw-dist/ubuntu20.04/
-        cp -r sql/ tibero-fdw-dist/ubuntu20.04/
-        cp -r expected/ tibero-fdw-dist/ubuntu20.04/
+        cp tibero_fdw.so tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp tibero_fdw.control tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp *.sql tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp Makefile tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp setenv.sh tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r sql/ tibero-fdw-dist/${{ env.BUILD_OS }}/
+        cp -r expected/ tibero-fdw-dist/${{ env.BUILD_OS }}/
         cd lib/
-        cp * ../tibero-fdw-dist/ubuntu20.04/lib/
+        cp * ../tibero-fdw-dist/${{ env.BUILD_OS }}/lib/
         
-        cd ../tibero-fdw-dist/ubuntu20.04/
-        ls
+        cd ../tibero-fdw-dist/${{ env.BUILD_OS }}/
         git add .
         if [[ -n $(git diff --cached --exit-code) ]]; then
           git commit -m "Deploy libraries"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,36 @@
+name: Main action
+
+on:                                                                              
+  workflow_dispatch:                                                             
+  push:
+    branches:                                                                    
+      - main
+  pull_request:
+    branches:
+      - main                                                                     
+
+jobs:
+  deploy-tibero-fdw-ubuntu:
+    uses: ./.github/workflows/deploy-tibero-fdw-ubuntu20.04.yaml
+    secrets: 
+      git-access-token: ${{ secrets.HYPERSQL_GITHUB_ACCESS_TOKEN }}
+
+  deploy-tibero-fdw-centos7:
+    uses: ./.github/workflows/deploy-tibero-fdw-centos7.yaml
+    secrets: 
+      git-access-token: ${{ secrets.HYPERSQL_GITHUB_ACCESS_TOKEN }}
+
+  deploy-tibero-fdw-centos8:
+    uses: ./.github/workflows/deploy-tibero-fdw-centos8.yaml
+    secrets: 
+      git-access-token: ${{ secrets.HYPERSQL_GITHUB_ACCESS_TOKEN }}
+
+  deploy-tibero-fdw-redhat7:
+    uses: ./.github/workflows/deploy-tibero-fdw-redhat7.yaml
+    secrets: 
+      git-access-token: ${{ secrets.HYPERSQL_GITHUB_ACCESS_TOKEN }}
+
+  deploy-tibero-fdw-redhat8:
+    uses: ./.github/workflows/deploy-tibero-fdw-redhat8.yaml
+    secrets: 
+      git-access-token: ${{ secrets.HYPERSQL_GITHUB_ACCESS_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ MODULE_big = tibero_fdw
 OBJS = utils.o deparse.o connection.o tibero_fdw.o
 PGFILEDESC = "tibero_fdw - foreign data wrapper for Tibero"
 
+# remove object file
+OBJS :=$(filter-out utils.o deparse.o connection.o tibero_fdw.o, $(OBJS))
+
 PG_CPPFLAGS = -I./include
 PG_LDFLAGS = -L./lib
 SHLIB_LINK = -ltbcli


### PR DESCRIPTION
Classification:
Other
Content:

1. Add tibero-fdw github action for deployment
 - ubuntu20.04
 - centos7
 - centos8
 - redhat7
 - redhat8

2. Makefile modification

  modifing not to copy unneccesary object files during "make install" step.
Reproduction steps:
n/a