### PR TITLE
Implement RescanForeignScan handler function

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -452,6 +452,7 @@ TbSQLExecute(TbStatement *tbStmt)
 	SQLRETURN rc = SQLExecute(tbStmt->hstmt);
 	if (rc == SQL_SUCCESS || rc == SQL_SUCCESS_WITH_INFO) {
 		/* TODO Add processing for SQL_SUCCESS_WITH_INFO */
+		tbStmt->query_executed = true;
 	} else {
 		TbFdwReportError(ERROR, ERRCODE_FDW_ERROR,
 										 psprintf("return code (%d)", rc), tbStmt->conn);

--- a/connection.h
+++ b/connection.h
@@ -48,6 +48,7 @@ typedef struct TbStatement
 	char tsn[32];
 	ConnCacheEntry *conn;
 	SQLSMALLINT res_col_cnt;
+	bool query_executed;
 } TbStatement;
 
 /* {{{ tbcli wrapper **********************************************************/

--- a/sql/join.sql
+++ b/sql/join.sql
@@ -2,7 +2,7 @@
 BEGIN;
   CREATE EXTENSION IF NOT EXISTS pgtap;
 
-  SELECT plan(37);
+  SELECT plan(38);
 
   CREATE EXTENSION IF NOT EXISTS tibero_fdw;
 
@@ -783,6 +783,29 @@ BEGIN;
       123456.123456789::FLOAT
     )$$,
     'Verify query results for CROSS JOIN multiple foreign table'
+  );
+
+  CREATE FOREIGN TABLE fst1 (
+      c1 INT
+  ) SERVER server_name OPTIONS (owner_name :TIBERO_USER, table_name 'st1');
+
+  CREATE FOREIGN TABLE fst2 (
+      c1 INT
+  ) SERVER server_name OPTIONS (owner_name :TIBERO_USER, table_name 'st2');
+
+  -- TEST 38
+  SELECT results_eq('
+    SELECT * FROM fst1, fst2 where fst1.c1 <= 200;',
+    $$VALUES
+      (100::INT, 10::INT),
+      (100::INT, 20::INT),
+      (100::INT, 30::INT),
+      (100::INT, 40::INT),
+      (200::INT, 10::INT),
+      (200::INT, 20::INT),
+      (200::INT, 30::INT),
+      (200::INT, 40::INT)
+    $$
   );
 
   -- Finish the tests and clean up.

--- a/tibero_fdw.c
+++ b/tibero_fdw.c
@@ -473,13 +473,14 @@ tiberoBeginForeignScan(ForeignScanState *node, int eflags)
 									 (SQLPOINTER)fsstate->fetch_size, 0);
 	TbSQLSetStmtAttr(fsstate->tbStmt, SQL_ATTR_ROWS_FETCHED_PTR,
 									 (SQLPOINTER)&fsstate->tuple_cnt, 0);
-	TbSQLExecute(fsstate->tbStmt);
 
 	for (i = 0; i < fsstate->tbStmt->res_col_cnt; i++) {
 		TbColumn *col = fsstate->table->column[i];
 		TbSQLBindCol(fsstate->tbStmt, i + 1, SQL_C_CHAR, (SQLCHAR *)col->data,
 								 col->col_size, col->ind);
 	}
+
+	fsstate->tbStmt->query_executed = false;
 
 	set_sleep_on_sig_off();
 }
@@ -598,6 +599,10 @@ tiberoIterateForeignScan(ForeignScanState *node)
 
 	set_sleep_on_sig_on();
 
+	if (!fsstate->tbStmt->query_executed) {
+		TbSQLExecute(fsstate->tbStmt);
+	}
+
 	if (need_fetch_tuples(fsstate))
 		fetch_tuples(node);
 	result_tts = get_next_tuple(node);
@@ -610,9 +615,13 @@ tiberoIterateForeignScan(ForeignScanState *node)
 static void
 tiberoReScanForeignScan(ForeignScanState *node)
 {
+	TbFdwScanState *fsstate = (TbFdwScanState *) node->fdw_state;
+
 	set_sleep_on_sig_on();
 
-	/* TODO */
+	fsstate->end_of_fetch = false;
+	fsstate->cur_tuple_idx = 0;
+	fsstate->tbStmt->query_executed = false;
 
 	set_sleep_on_sig_off();
 }


### PR DESCRIPTION
Classification: Implementation
Content:
- Implemented RescanForeignScan handler function to re-execute query statement Reproduction steps:
Execute cartesian product query
- See sql/join.sql - TEST 38
```sql
CREATE FOREIGN TABLE fst1 (
    c1 INT
) SERVER server_name OPTIONS (owner_name :TIBERO_USER, table_name 'st1');

CREATE FOREIGN TABLE fst2 (
    c1 INT
) SERVER server_name OPTIONS (owner_name :TIBERO_USER, table_name 'st2');

SELECT * FROM fst1, fst2 where fst1.c1 <= 200;
```