### PR TITLE
Minor fix for github-action

### DIFF
--- a/.github/workflows/deploy-pg15-tibero-fdw-centos7.yaml
+++ b/.github/workflows/deploy-pg15-tibero-fdw-centos7.yaml
@@ -1,4 +1,4 @@
-name: deploy-postgresql15-tibero-fdw-centos7
+name: deploy-pg15-tibero-fdw-centos7
 
 on:
   release:

--- a/.github/workflows/deploy-pg16-tibero-fdw-centos7.yaml
+++ b/.github/workflows/deploy-pg16-tibero-fdw-centos7.yaml
@@ -1,4 +1,4 @@
-name: deploy-postgresql16-tibero-fdw-centos7
+name: deploy-pg16-tibero-fdw-centos7
 
 on:
   release:


### PR DESCRIPTION
Classification: Other
Content:
commit for release new tibero-fdw release version to make github-action works
Reproduction steps:
github-workflow

## Classification
- [ ] Feature
- [ ] Hotfix
- [ ] Patch
- [O] Others

## Content
-Modify github action to release tibero-fdw for PostgreSQL 15,16 and
Redhat9

PostgreSQL14 for centos7,centos8,redhat8,redhat9
PostgreSQL15 for centos7,centos8,redhat8,redhat9
PostgreSQL16 for centos7,centos8,redhat8,redhat9

## Reproduction Steps
-github workflow
