### PR TITLE
release tibero-fdw for ubuntu 20.04, ubuntu22

### DIFF
--- a/.github/workflows/deploy-pg14-tibero-fdw-redhat9.yaml
+++ b/.github/workflows/deploy-pg14-tibero-fdw-redhat9.yaml
@@ -1,6 +1,7 @@
 name: deploy-pg14-tibero-fdw-redhat9
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/deploy-pg15-tibero-fdw-redhat9.yaml
+++ b/.github/workflows/deploy-pg15-tibero-fdw-redhat9.yaml
@@ -1,6 +1,7 @@
 name: deploy-pg15-tibero-fdw-redhat9
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
Classification: Other
Content:
release tibero-fdw for ubuntu
Reproduction steps:
github workflow

## Classification
- [ ] Feature
- [ ] Hotfix
- [ ] Patch
- [O] Others

## Content
Add github-action for release automation of tibero-fdw for Ubuntu

PostgreSQL14 for ubuntu20.04, ubuntu22
PostgreSQL15 for ubuntu20.04, ubuntu22

## Reproduction Steps
github workflow
